### PR TITLE
feat:magic-link flow with integration of resend

### DIFF
--- a/src/actions/sign-in.ts
+++ b/src/actions/sign-in.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { signIn } from "@/auth";
-import { LoginSchema } from "@/lib/definitions";
+import { LoginSchema, MagicLinkSchema } from "@/lib/definitions";
 import { parseWithZod } from "@conform-to/zod";
 export async function signInGithub() {
   return signIn("github", { redirectTo: "/dashboard" });
@@ -28,6 +28,25 @@ export async function signInCredentials(state: unknown, formData: FormData) {
       redirectTo: "/dashboard",
     });
 
+    return result
+  } catch (error) {
+    return parsedCredentials.reply({
+      formErrors: ["An error occurred during sign in"],
+    });
+  }
+}
+
+export async function signInMagicLink(state: unknown, formData: FormData) {
+  const parsedCredentials = parseWithZod(formData, { schema: MagicLinkSchema });
+  if (parsedCredentials.status !== 'success') {
+    return parsedCredentials.reply({
+      formErrors: ["Invalid email"],
+    });
+  }
+  const { email } = parsedCredentials.value;
+
+  try {
+    const result = await signIn("resend", { email });
     return result
   } catch (error) {
     return parsedCredentials.reply({

--- a/src/app/login/components/login.tsx
+++ b/src/app/login/components/login.tsx
@@ -9,6 +9,7 @@ import { useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod";
 import { LoginSchema } from "@/lib/definitions";
 import { useRouter } from "next/navigation";
+import { MagicLinkForm } from "./magic-link-form";
 
 export const Login = () => {
   const [isVisible, setIsVisible] = React.useState(false);
@@ -90,6 +91,17 @@ export const Login = () => {
             Log In
           </Button>
         </form>
+        <div className="flex items-center gap-4 py-2">
+          <Divider className="flex-1" />
+          <p className="shrink-0 text-tiny text-default-500">OR</p>
+          <Divider className="flex-1" />
+        </div>
+        <div className="flex flex-col gap-2">
+         <p className="text-center text-sm text-default-500">
+           Sign in with Magic Link
+         </p>
+         <MagicLinkForm />
+       </div>
         <div className="flex items-center gap-4 py-2">
           <Divider className="flex-1" />
           <p className="shrink-0 text-tiny text-default-500">OR</p>

--- a/src/app/login/components/magic-link-form.tsx
+++ b/src/app/login/components/magic-link-form.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@heroui/react'
+import React from 'react'
+import { signInMagicLink } from '@/actions/sign-in'
+import { Input } from '@heroui/react'
+import { useActionState } from 'react'
+import { useForm } from '@conform-to/react'
+import { parseWithZod } from '@conform-to/zod'
+import { MagicLinkSchema } from '@/lib/definitions'
+
+export const MagicLinkForm = () => {
+  const [lastResult, actionSignInMagicLink, isPending] = useActionState(signInMagicLink, undefined)
+
+  const [form, fields] = useForm({
+    lastResult,
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: MagicLinkSchema })
+    },
+    shouldValidate: 'onBlur',
+    shouldRevalidate: 'onInput',
+  });
+
+  console.log({lastResult})
+
+  return (
+    <form id={form.id} action={actionSignInMagicLink} onSubmit={form.onSubmit} className="flex flex-col gap-2">
+        <Input 
+            type="email" 
+            name={fields.email.name} 
+            variant="bordered" 
+            placeholder="Email" 
+            key={fields.email.key} 
+            defaultValue={fields.email.value} 
+            errorMessage={fields.email.errors} 
+            isInvalid={!!fields.email.errors?.length} 
+        />
+        <Button color="secondary" type="submit" isLoading={isPending}>Send Magic Link</Button>
+    </form>
+  )
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/prisma";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
 import Credentials from "next-auth/providers/credentials";
+import Resend from "next-auth/providers/resend"
 import bcrypt from "bcryptjs";
 import { LoginSchema } from "./lib/definitions";
 import { getUser } from "./actions/user";
@@ -11,6 +12,10 @@ import { getUser } from "./actions/user";
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: PrismaAdapter(prisma),
   providers: [
+    Resend({
+      from: process.env.RESEND_FROM,
+      apiKey: process.env.RESEND_API_KEY,
+    }),
     GitHub({
       clientId: process.env.AUTH_GITHUB_ID,
       clientSecret: process.env.AUTH_GITHUB_SECRET,

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -49,3 +49,10 @@ export const LoginSchema = z.object({
 })
 
 export type LoginFormType = z.infer<typeof LoginSchema>
+
+
+export const MagicLinkSchema = z.object({
+  email: z.string().email('Invalid email address'),
+})
+
+export type MagicLinkFormType = z.infer<typeof MagicLinkSchema>


### PR DESCRIPTION
This pull request introduces the "Magic Link" sign-in feature, allowing users to sign in using a magic link sent to their email. The most important changes include the addition of the `MagicLinkSchema`, the new `signInMagicLink` function, and updates to the login form to support this new sign-in method.

### Magic Link Sign-In Feature:

* [`src/lib/definitions.ts`](diffhunk://#diff-0657ba9d31ee51c90df039fc9e0af6deaf6170b84ada1ed7943da2604f014239R52-R58): Added `MagicLinkSchema` for validating magic link sign-in requests.
* [`src/actions/sign-in.ts`](diffhunk://#diff-e4a0cd6cf1a9702c4b7e0455c25124324357af27bd0f4c7f53a60e075dbc6f69R38-R56): Introduced the `signInMagicLink` function to handle magic link sign-in requests.
* [`src/app/login/components/magic-link-form.tsx`](diffhunk://#diff-a13e6a6f5a45d919fbf554f7355f1edd742240a3baf52ef57f0f7043a478b544R1-R39): Created the `MagicLinkForm` component to handle the magic link sign-in form.

### Integration with Existing Login Flow:

* [`src/app/login/components/login.tsx`](diffhunk://#diff-e60f18f4a81907c46db2fb82e94f748a6c9ae56139584d217bd84a2bdf78501aR12): Updated the login component to include the `MagicLinkForm` and added UI elements to switch between traditional sign-in and magic link sign-in. [[1]](diffhunk://#diff-e60f18f4a81907c46db2fb82e94f748a6c9ae56139584d217bd84a2bdf78501aR12) [[2]](diffhunk://#diff-e60f18f4a81907c46db2fb82e94f748a6c9ae56139584d217bd84a2bdf78501aR94-R104)

### Authentication Provider Update:

* [`src/auth.ts`](diffhunk://#diff-84a5d130fb4cccb80f78601d140f1d5397dc0272f94cea672a8470539fcf6dc7R7-R18): Added the `Resend` provider to support sending magic links via email.